### PR TITLE
chore: Bump dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-argocd 2.5.4
+argocd 2.5.7

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ version: 1.0.0
 dependencies:
 - alias: argocd-source
   name: argo-cd
-  version: 5.16.14
+  version: 5.19.6
   repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Bump the argocd chart version to 5.19.6

Align `.tool-versions` argocd CLI version to the one defined here: https://github.com/argoproj/argo-helm/blob/argo-cd-5.19.6/charts/argo-cd/Chart.yaml#L2